### PR TITLE
fix: increase maxBuffer to 256MB to prevent ENOBUFS on large chat export

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -118,10 +118,11 @@ function execSqlite3(dbPath, sql) {
 	
 	try {
 		// Use -cmd to set busy timeout for concurrent access
+		// 256MB buffer to avoid ENOBUFS on large chats (see https://github.com/ibrahim317/cursor-chat-transfer/issues/7)
 		return execFileSync(sqlite3Path, ['-cmd', '.timeout 5000', dbPath], {
 			input: sql,
 			encoding: 'utf8',
-			maxBuffer: 50 * 1024 * 1024 // 50MB buffer
+			maxBuffer: 256 * 1024 * 1024
 		});
 	} catch (err) {
 		console.error('[sqlite3] Error executing SQL:', err.message);
@@ -191,7 +192,7 @@ function insertKVWithCLI(dbPath, keyValuePairs) {
 		execFileSync(sqlite3Path, ['-cmd', '.timeout 5000', dbPath], {
 			input: sql,
 			encoding: 'utf8',
-			maxBuffer: 50 * 1024 * 1024
+			maxBuffer: 256 * 1024 * 1024
 		});
 		return keyValuePairs.length;
 	} catch (err) {
@@ -216,7 +217,8 @@ function updateItemTableWithCLI(dbPath, key, value) {
 	try {
 		execFileSync(sqlite3Path, ['-cmd', '.timeout 5000', dbPath], {
 			input: sql,
-			encoding: 'utf8'
+			encoding: 'utf8',
+			maxBuffer: 256 * 1024 * 1024
 		});
 	} catch (err) {
 		console.error('[sqlite3] Error updating ItemTable:', err.message);
@@ -257,7 +259,7 @@ function createBackup(dbPath) {
 	const sqlite3Path = findSqlite3();
 	if (sqlite3Path) {
 		try {
-			execSync(`"${sqlite3Path}" "${dbPath}" ".backup '${backupPath}'"`, { encoding: 'utf8' });
+			execSync(`"${sqlite3Path}" "${dbPath}" ".backup '${backupPath}'"`, { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
 			return backupPath;
 		} catch (e) {
 			console.warn('[db] sqlite3 backup failed, falling back to file copy:', e.message);
@@ -327,7 +329,8 @@ async function checkIntegrity(dbPath) {
 	
 	try {
 		const result = execFileSync(sqlite3Path, [dbPath, 'PRAGMA integrity_check;'], {
-			encoding: 'utf8'
+			encoding: 'utf8',
+			maxBuffer: 256 * 1024 * 1024
 		});
 		return result.trim() === 'ok';
 	} catch (err) {


### PR DESCRIPTION
## Problem
Export fails with `spawnSync sqlite3 ENOBUFS` when exporting chats with many messages or large code. The 50MB buffer is too small for the hex-encoded SQLite output.

Ref: #7

## Solution
Raised `maxBuffer` to 256MB in all sqlite3 calls in `lib/db.js` and set it where it was missing (`updateItemTableWithCLI`, `checkIntegrity`, `createBackup`).

## Testing
Export chats in a workspace where export used to fail with ENOBUFS. It should complete without error.